### PR TITLE
Feature/user/user interceptor refactor

### DIFF
--- a/src/main/java/com/seungwooryu/woostagram/common/errors/AuthenticationException.java
+++ b/src/main/java/com/seungwooryu/woostagram/common/errors/AuthenticationException.java
@@ -1,4 +1,4 @@
-package com.seungwooryu.woostagram.user.errors;
+package com.seungwooryu.woostagram.common.errors;
 
 
 import lombok.Getter;

--- a/src/main/java/com/seungwooryu/woostagram/common/errors/CustomException.java
+++ b/src/main/java/com/seungwooryu/woostagram/common/errors/CustomException.java
@@ -1,4 +1,4 @@
-package com.seungwooryu.woostagram.user.errors;
+package com.seungwooryu.woostagram.common.errors;
 
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/seungwooryu/woostagram/common/errors/DuplicatedArgumentException.java
+++ b/src/main/java/com/seungwooryu/woostagram/common/errors/DuplicatedArgumentException.java
@@ -1,4 +1,4 @@
-package com.seungwooryu.woostagram.user.errors;
+package com.seungwooryu.woostagram.common.errors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;

--- a/src/main/java/com/seungwooryu/woostagram/common/errors/GeneralExceptionHandler.java
+++ b/src/main/java/com/seungwooryu/woostagram/common/errors/GeneralExceptionHandler.java
@@ -1,6 +1,5 @@
-package com.seungwooryu.woostagram.user.errors;
+package com.seungwooryu.woostagram.common.errors;
 
-import com.seungwooryu.woostagram.user.controller.UserController;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +15,7 @@ import java.util.Optional;
 import static com.seungwooryu.woostagram.common.utils.ApiUtils.*;
 import static java.util.stream.Collectors.toList;
 
-@RestControllerAdvice(basePackageClasses = UserController.class)
+@RestControllerAdvice
 @Slf4j
 public class GeneralExceptionHandler {
 

--- a/src/main/java/com/seungwooryu/woostagram/common/errors/UserNotFoundException.java
+++ b/src/main/java/com/seungwooryu/woostagram/common/errors/UserNotFoundException.java
@@ -1,4 +1,4 @@
-package com.seungwooryu.woostagram.user.errors;
+package com.seungwooryu.woostagram.common.errors;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;

--- a/src/main/java/com/seungwooryu/woostagram/post/controller/PostController.java
+++ b/src/main/java/com/seungwooryu/woostagram/post/controller/PostController.java
@@ -1,0 +1,36 @@
+package com.seungwooryu.woostagram.post.controller;
+
+import com.seungwooryu.woostagram.common.utils.ApiUtils.ApiResult;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import static com.seungwooryu.woostagram.common.utils.ApiUtils.success;
+
+@Slf4j
+@RestController
+@RequestMapping("/post")
+public class PostController {
+    @PostMapping
+    public ResponseEntity<ApiResult<?>> upload(@RequestPart(value = "image_file", required = false) MultipartFile imageFile, @RequestParam String content) {
+        System.out.println(imageFile.getOriginalFilename());
+        System.out.println(content);
+
+        return new ResponseEntity<>(success(null), HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResult<?>> delete(@PathVariable int id) {
+
+        return new ResponseEntity<>(success(null), HttpStatus.OK);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResult<?>> update(MultipartFile file, String content, @PathVariable int id) {
+
+        return new ResponseEntity<>(success(null), HttpStatus.OK);
+    }
+
+}

--- a/src/main/java/com/seungwooryu/woostagram/post/dto/PostDto.java
+++ b/src/main/java/com/seungwooryu/woostagram/post/dto/PostDto.java
@@ -1,0 +1,14 @@
+package com.seungwooryu.woostagram.post.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@ToString
+public class PostDto {
+    private MultipartFile imageFile;
+    private String contents;
+}

--- a/src/main/java/com/seungwooryu/woostagram/post/service/FileService.java
+++ b/src/main/java/com/seungwooryu/woostagram/post/service/FileService.java
@@ -1,0 +1,9 @@
+package com.seungwooryu.woostagram.post.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileService {
+    public String upload(MultipartFile file);
+
+    public Boolean delete(String fileURI);
+}

--- a/src/main/java/com/seungwooryu/woostagram/post/service/LocalFileService.java
+++ b/src/main/java/com/seungwooryu/woostagram/post/service/LocalFileService.java
@@ -1,0 +1,17 @@
+package com.seungwooryu.woostagram.post.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public class LocalFileService implements FileService {
+    private static final String FILE_ = "위치 어디로";
+
+    @Override
+    public String upload(MultipartFile file) {
+        return null;
+    }
+
+    @Override
+    public Boolean delete(String fileURI) {
+        return null;
+    }
+}

--- a/src/main/java/com/seungwooryu/woostagram/post/service/PostService.java
+++ b/src/main/java/com/seungwooryu/woostagram/post/service/PostService.java
@@ -1,0 +1,7 @@
+package com.seungwooryu.woostagram.post.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostService {
+}

--- a/src/main/java/com/seungwooryu/woostagram/user/interceptor/SigninCheckInterceptor.java
+++ b/src/main/java/com/seungwooryu/woostagram/user/interceptor/SigninCheckInterceptor.java
@@ -1,6 +1,6 @@
 package com.seungwooryu.woostagram.user.interceptor;
 
-import com.seungwooryu.woostagram.user.errors.AuthenticationException;
+import com.seungwooryu.woostagram.common.errors.AuthenticationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.HandlerInterceptor;

--- a/src/main/java/com/seungwooryu/woostagram/user/service/UserService.java
+++ b/src/main/java/com/seungwooryu/woostagram/user/service/UserService.java
@@ -1,11 +1,11 @@
 package com.seungwooryu.woostagram.user.service;
 
+import com.seungwooryu.woostagram.common.errors.DuplicatedArgumentException;
+import com.seungwooryu.woostagram.common.errors.UserNotFoundException;
 import com.seungwooryu.woostagram.user.domain.User;
 import com.seungwooryu.woostagram.user.dto.SigninDto;
 import com.seungwooryu.woostagram.user.dto.SignupDto;
 import com.seungwooryu.woostagram.user.dto.UserDto;
-import com.seungwooryu.woostagram.user.errors.DuplicatedArgumentException;
-import com.seungwooryu.woostagram.user.errors.UserNotFoundException;
 import com.seungwooryu.woostagram.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
### 문제
- interceptor에서 throw exception하게되면 오류를 was로 던져주면서 spring이 제공하는 기본 오류 페이지를 리턴한다.

### 해결
- @RestControllAdvice의 범위를 UserController.class로 한정지어서 일어난 일. PostController를 담당하는 인터셉터의 preHandle에서 throw AuthenticationException해서 캐치하지 못 했다.